### PR TITLE
Minor rewrite while adding keybind

### DIFF
--- a/toggle-tree.js
+++ b/toggle-tree.js
@@ -1,13 +1,28 @@
-(function() {
+(function () {
+
+	function toggleView() {
+		var tree = document.querySelector("#tree-td");
+		if (tree) {
+			tree.style.display = tree.style.display == "none" ? "" : "none";
+			GMEdit_Splitter.syncMain();
+		} else {
+			console.error("Could not find resource tree view");
+		}
+	}
+
 	GMEdit.register("toggle-tree", {
-		init: function() {
-			var tree = document.querySelector("#tree-td");
-			if (tree) $gmedit["ui.CommandPalette"].add({
-				name: "Toggle treeview",
-				exec: function() {
-					tree.style.display = tree.style.display == "none" ? "" : "none";
-					GMEdit_Splitter.syncMain();
+		init: function () {
+			AceCommands.add({
+				name: "toggleResourceView",
+				bindKey: "Ctrl-Shift-B",
+				exec: function (editor) {
+					toggleView();
 				}
+			});
+
+			AceCommands.addToPalette({
+				name: "Toggle Resource View",
+				exec: "toggleResourceView"
 			});
 		}
 	});


### PR DESCRIPTION
Rewrote to be in line with other plugins.
This will make other potential changes easier to handle.
Specifically, I'm investigating moving the system button when the resource tree is closed.

Also added the option of a keybind with the default `Ctrl+Shift+B`.