### PR TITLE
System hamberger button can be moved when toggling resource tree

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
 	"name": "toggle-tree",
-	"scripts": ["toggle-tree.js"]
+	"scripts": ["toggle-tree.js"],
+	"stylesheets": ["toggle-tree.css"]
 }

--- a/toggle-tree.css
+++ b/toggle-tree.css
@@ -1,0 +1,17 @@
+.system-buttons.hamburger.hamburger-hidden {
+    left: 0;
+    display: flex;
+}
+
+#button-slot {
+    float: left;
+    width: 30px;
+    height: 100%;
+    margin: 0%;
+}
+
+/* Adjust to account for button slot */
+.chrome-tabs-content.chrome-tabs-content-reduced {
+    float: left;
+    width: 95%;
+}

--- a/toggle-tree.js
+++ b/toggle-tree.js
@@ -1,29 +1,101 @@
 (function () {
+	var Preferences = $gmedit["ui.Preferences"];
+	var FileWrap = $gmedit["electron.FileWrap"];
+	var moveHamburger = true;
 
 	function toggleView() {
 		var tree = document.querySelector("#tree-td");
 		if (tree) {
 			tree.style.display = tree.style.display == "none" ? "" : "none";
+			updateHamburgerLocation();
 			GMEdit_Splitter.syncMain();
 		} else {
 			console.error("Could not find resource tree view");
 		}
 	}
 
-	GMEdit.register("toggle-tree", {
-		init: function () {
-			AceCommands.add({
-				name: "toggleResourceView",
-				bindKey: "Ctrl-Shift-B",
-				exec: function (editor) {
-					toggleView();
-				}
-			});
+	function updateHamburgerLocation() {
+		var tree = document.querySelector("#tree-td");
+		var hamburger = document.querySelector(".hamburger");
+		var buttonSapce = document.querySelector("#button-slot");
+		// Free up white space for tabs
+		buttonSapce.style.display = tree.style.display == "none" ? "" : "none";
 
-			AceCommands.addToPalette({
-				name: "Toggle Resource View",
-				exec: "toggleResourceView"
-			});
+		// Move the hamburger based on toggle state
+		if (tree.style.display == "") {
+			// Resource tree is shown, move hamburger next to project name
+			var projectName = document.querySelector(".project-name");
+			projectName.appendChild(hamburger);
+			// Re-query button, otherwise button will be duplicated
+			document.querySelector(".hamburger").classList.remove("hamburger-hidden");
+			document.querySelector(".chrome-tabs-content").classList.remove("chrome-tabs-content-reduced");
+		} else {
+			// Resource tree is hidden, move hamburger next to tabs
+			buttonSapce.appendChild(hamburger);
+			// Re-query button, otherwise button will be duplicated
+			document.querySelector(".hamburger").classList.add("hamburger-hidden");
+			document.querySelector(".chrome-tabs-content").classList.add("chrome-tabs-content-reduced");
 		}
+	}
+
+	function init() {
+		// Initialize new elements
+		document.querySelector(".system-buttons").classList.add("hamburger");
+		// TODO: save hidden state of resource tree in properties
+		var buttonSlot = document.createElement("div")
+		// Default button slot to hidden since resource tree is shown by default
+		buttonSlot.style.display = "none";
+		buttonSlot.id = "button-slot"
+		document.querySelector("#tabs").prepend(buttonSlot);
+
+		function prepareTRT() {
+			var currentPrefs = Preferences.current.toggleResourceView;
+			if (!currentPrefs) currentPrefs = Preferences.current.toggleResourceView = {};
+			return currentPrefs;
+		}
+
+		function opt(ov, name, def) {
+			if (!ov) return def;
+			var val = ov[name];
+			return val !== undefined ? val : def;
+		}
+
+		AceCommands.add({
+			name: "toggleResourceView",
+			bindKey: "Ctrl-Shift-B",
+			exec: function (editor) {
+				toggleView();
+				var currPrefs = FileWrap.readConfigSync("config", Preferences.path);
+				if (currPrefs) {
+					var currTRT = currPrefs.toggleResourceView;
+					if (currTRT == null) currTRT = currPrefs.toggleResourceView = {};
+					FileWrap.writeConfigSync("config", Preferences.path, currPrefs);
+				}
+			}
+		});
+
+		AceCommands.addToPalette({
+			name: "Toggle Resource View",
+			exec: "toggleResourceView"
+		});
+
+		GMEdit.on("preferencesBuilt", function (e) {
+			var out = e.target.querySelector('.plugin-settings[for="toggle-tree"]');
+			var currTRT = Preferences.current.toggleResourceView;
+			moveHamburger = opt(currTRT, "moveHamburger", true);
+
+
+			Preferences.addCheckbox(out, "Show hamburger when resource tree is closed", opt(currTRT, "moveHamburger", true), function (val) {
+				var currTRT = prepareTRT();
+				showFuncArgs = currTRT.moveHamburger = val;
+				updateHamburgerLocation();
+				Preferences.save();
+				forceRefresh();
+			});
+		});
+	}
+
+	GMEdit.register("toggle-tree", {
+		init: init
 	});
 })();

--- a/toggle-tree.js
+++ b/toggle-tree.js
@@ -15,39 +15,51 @@
 	}
 
 	function updateHamburgerLocation() {
+		var currTRV = FileWrap.readConfigSync("config", Preferences.path).toggleResourceView;
 		var tree = document.querySelector("#tree-td");
 		var hamburger = document.querySelector(".hamburger");
 		var buttonSapce = document.querySelector("#button-slot");
 		// Free up white space for tabs
-		buttonSapce.style.display = tree.style.display == "none" ? "" : "none";
-
-		// Move the hamburger based on toggle state
-		if (tree.style.display == "") {
-			// Resource tree is shown, move hamburger next to project name
+		
+		// Check preferences to see if hamberger is to be moved
+		if (currTRV.moveHamburger) {
+			buttonSapce.style.display = tree.style.display == "none" ? "" : "none";
+			// Move the hamburger based on toggle state
+			if (tree.style.display == "") {
+				// Resource tree is shown, move hamburger next to project name
+				var projectName = document.querySelector(".project-name");
+				projectName.appendChild(hamburger);
+				// Re-query button, otherwise button will be duplicated
+				document.querySelector(".hamburger").classList.remove("hamburger-hidden");
+				document.querySelector(".chrome-tabs-content").classList.remove("chrome-tabs-content-reduced");
+			} else {
+				// Resource tree is hidden, move hamburger next to tabs
+				buttonSapce.appendChild(hamburger);
+				// Re-query button, otherwise button will be duplicated
+				document.querySelector(".hamburger").classList.add("hamburger-hidden");
+				document.querySelector(".chrome-tabs-content").classList.add("chrome-tabs-content-reduced");
+			}
+		} else {
+			buttonSapce.style.display = "none";
+			// if hamberger isn't supposed to be moved, force into original position
 			var projectName = document.querySelector(".project-name");
 			projectName.appendChild(hamburger);
 			// Re-query button, otherwise button will be duplicated
 			document.querySelector(".hamburger").classList.remove("hamburger-hidden");
 			document.querySelector(".chrome-tabs-content").classList.remove("chrome-tabs-content-reduced");
-		} else {
-			// Resource tree is hidden, move hamburger next to tabs
-			buttonSapce.appendChild(hamburger);
-			// Re-query button, otherwise button will be duplicated
-			document.querySelector(".hamburger").classList.add("hamburger-hidden");
-			document.querySelector(".chrome-tabs-content").classList.add("chrome-tabs-content-reduced");
 		}
 	}
 
 	function init() {
 		// Initialize new elements
 		document.querySelector(".system-buttons").classList.add("hamburger");
-		// TODO: save hidden state of resource tree in properties
 		var buttonSlot = document.createElement("div")
 		// Default button slot to hidden since resource tree is shown by default
 		buttonSlot.style.display = "none";
 		buttonSlot.id = "button-slot"
 		document.querySelector("#tabs").prepend(buttonSlot);
 
+		// Prepare toggled resource tree preferences
 		function prepareTRT() {
 			var currentPrefs = Preferences.current.toggleResourceView;
 			if (!currentPrefs) currentPrefs = Preferences.current.toggleResourceView = {};
@@ -88,8 +100,8 @@
 			Preferences.addCheckbox(out, "Show hamburger when resource tree is closed", opt(currTRT, "moveHamburger", true), function (val) {
 				var currTRT = prepareTRT();
 				showFuncArgs = currTRT.moveHamburger = val;
-				updateHamburgerLocation();
 				Preferences.save();
+				updateHamburgerLocation();
 				forceRefresh();
 			});
 		});


### PR DESCRIPTION
When the resource tree is collapsed, the system "hamburger" button is moved next to the tabs.

![gmedit-before](https://user-images.githubusercontent.com/6466091/146107364-32e0a174-7872-40d1-bd8a-455e09f07efc.PNG)

![gmedit-after](https://user-images.githubusercontent.com/6466091/146107469-e9ae5a84-8fd5-4b78-96b9-8e200a861ac8.png)

Is togglable in system preferences:
![option](https://user-images.githubusercontent.com/6466091/147988504-8e97115d-6a77-454c-98e3-9cbad8d866b8.PNG)

